### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.DS_Store
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+FROM node:12-alpine AS build-client
+
+RUN mkdir /client && chown node:node /client
+
+WORKDIR /client
+
+COPY ./client/package*.json /client/
+
+RUN npm ci
+
+COPY ./client .
+
+RUN npm run build
+
+RUN npm prune --production
+
+FROM node:12-alpine AS server-deps
+
+RUN mkdir /server && chown node:node /server
+
+WORKDIR /server
+
+COPY ./server/package*.json /server/
+
+RUN apk add --no-cache sqlite sqlite-dev sqlite-libs python g++ make gcc curl git \
+    && npm ci --production
+
+FROM node:12-alpine AS production
+
+RUN apk add --no-cache ffmpeg
+
+RUN mkdir /db && chmod -R a+rw /db
+
+USER 1000
+
+WORKDIR /app
+
+COPY --from=build-client --chown=root:root /client/dist/rdio-scanner /app/client
+
+COPY --chown=root:root ./server /app/server
+
+COPY --from=server-deps --chown=root:root /server/node_modules /app/server/node_modules
+
+COPY --chown=root:root ./entrypoint.sh .
+
+EXPOSE 3000
+
+ENV CLIENT_HTML_DIR=/app/client
+
+CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -170,3 +170,34 @@ You can update your *Rdio Scanner* instance with this simple command:
 ```bash
 $ node update.js
 ```
+
+## Docker
+
+You can also run rdio-scanner via Docker.
+
+```
+docker run -it -p 3000:3000 \
+ -v /home/pi/trunk-recorder/rdio_config.json:/app/server/config.json \
+ -v /home/pi/trunk-recorder/media:/calls \
+ -v /home/pi/trunk-recorder/rdio.db:/db/rdio.db \
+ -e DB_STORAGE="/db/rdio.db" \
+ robbiet480/rdio-scanner:latest
+```
+
+Or via Docker Compose:
+
+```yaml
+version: '3'
+volumes:
+  rdio_database:
+services:
+  rdio:
+    image: robbiet480/rdio-scanner:latest
+    container_name: rdio-scanner
+    volumes:
+      - ./rdio_config.json:/app/server/config.json
+      - rdio_database:/db
+      - ./media:/calls
+    environment:
+      - "DB_STORAGE=/db/rdio.db"
+```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cd ./server
+npm run migrate
+npm start

--- a/server/index.js
+++ b/server/index.js
@@ -76,7 +76,7 @@ class App {
     }
 
     constructor() {
-        const staticDir = '../client/dist/rdio-scanner';
+        const staticDir = process.env.CLIENT_HTML_DIR || '../client/dist/rdio-scanner';
         const staticFile = 'index.html';
 
         this.config = App.Config();
@@ -85,7 +85,7 @@ class App {
         this.router.use(express.json());
         this.router.use(express.urlencoded({ extended: false }));
         this.router.use(express.static(staticDir));
-        this.router.set(this.config.nodejs.port);
+        this.router.set(process.env.PORT || this.config.nodejs.port);
 
         if (this.config.nodejs.env !== 'development') {
             this.router.disable('x-powered-by');

--- a/server/lib/rdio-scanner/controller.js
+++ b/server/lib/rdio-scanner/controller.js
@@ -331,7 +331,7 @@ class Controller {
             return;
         }
 
-        if (call.autioType !== 'audio/aac') {
+        if (call.audioType !== 'audio/aac') {
             try {
                 call = await this.convertCallAudio(call);
 

--- a/server/lib/rdio-scanner/dir-watch.js
+++ b/server/lib/rdio-scanner/dir-watch.js
@@ -153,7 +153,7 @@ class DirWatch {
                     }
 
                 } catch (error) {
-                    console.error(`DirWatch: Error importing file ${audioFile}`);
+                    console.error(`DirWatch: Error importing file ${audioFile}`, error);
 
                     return;
                 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "rdio-scanner-server",
-    "version": "4.1.0",
+    "version": "4.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
This PR adds Docker support. Docker will allow users to get started much faster, especially on lower power platforms like Raspberry Pi. It also fixes a few issues I found as well as modifies server code to work better for Docker users.

Docker images for all relevant platforms can be built with `docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t chuot/rdio-scanner --push .`. @chuot I'd suggest signing up for Docker Hub and publishing the images there. You could automatically publish upon new release with a Github Action like [this](https://github.com/crazy-max/ghaction-docker-buildx). Otherwise, I'm happy for you to send people to [my images](https://hub.docker.com/r/robbiet480/rdio-scanner).

See also https://github.com/robotastic/trunk-recorder/issues/365.