### PR TITLE
Add durations

### DIFF
--- a/client/src/app/components/rdio-scanner/main/main.component.html
+++ b/client/src/app/components/rdio-scanner/main/main.component.html
@@ -23,6 +23,7 @@
             <span>{{ callTalkgroup }}</span>
         </div>
         <div>
+            <span>{{ callDuration / 1000 | number:'1.0-1' }}s</span> —
             <span>{{ callProgress | date:'HH:mm' }}</span>
         </div>
     </div>
@@ -57,32 +58,38 @@
         <table class="history">
             <thead>
                 <tr>
-                    <th>
+                    <th class="time">
                         <span>Time</span>
                     </th>
-                    <th>
+                    <th class="duration">
+                        <span>Length</span>
+                    </th>
+                    <th class="system">
                         <span>System</span>
                     </th>
-                    <th>
+                    <th class="talkgroup">
                         <span>Talkgroup</span>
                     </th>
-                    <th>
+                    <th class="name">
                         <span>Name</span>
                     </th>
                 </tr>
             </thead>
             <tbody>
                 <tr *ngFor="let previousCall of callHistory">
-                    <td>
+                    <td class="time">
                         <span>{{ previousCall?.dateTime | date:'HH:mm' }}</span>
                     </td>
-                    <td>
+                    <td class="duration">
+                        <span *ngIf="previousCall">{{ previousCall.audioDuration / 1000 | number:'1.0-1' }}s</span>
+                    </td>
+                    <td class="system">
                         <span>{{ previousCall?.systemData?.label || previousCall?.system}}</span>
                     </td>
-                    <td>
+                    <td class="talkgroup">
                         <span>{{ previousCall?.talkgroupData?.label || previousCall?.talkgroup }}</span>
                     </td>
-                    <td>
+                    <td class="name">
                         <span>{{ previousCall?.talkgroupData?.name || previousCall?.frequency }}</span>
                     </td>
                 </tr>

--- a/client/src/app/components/rdio-scanner/main/main.component.scss
+++ b/client/src/app/components/rdio-scanner/main/main.component.scss
@@ -102,13 +102,21 @@
       padding: 0;
       text-align: start;
 
-      &:nth-child(1) {
-        width: 10%;
+      &.time {
+        width: 7%;
+      }
+      &.duration {
+        width: 9%;
       }
 
-      &:nth-child(4) {
+      &.name {
         width: 50%;
       }
+    }
+
+    td.duration {
+      text-align: right;
+      padding-right: 1em;
     }
 
     th {

--- a/client/src/app/components/rdio-scanner/main/main.component.ts
+++ b/client/src/app/components/rdio-scanner/main/main.component.ts
@@ -45,6 +45,7 @@ export class AppRdioScannerMainComponent implements OnDestroy, OnInit {
     callHistory: RdioScannerCall[] = new Array<RdioScannerCall>(5);
     callPrevious: RdioScannerCall | undefined;
     callProgress = new Date(0, 0, 0, 0, 0, 0);
+    callDuration = 0;
     callQueue = 0;
     callSpike = '0';
     callSystem = 'System';
@@ -405,6 +406,8 @@ export class AppRdioScannerMainComponent implements OnDestroy, OnInit {
             this.callTalkgroup = this.call.talkgroupData?.label || `${this.call.talkgroup}`;
 
             this.callTalkgroupName = this.call.talkgroupData?.name || this.formatFrequency(this.call?.frequency);
+
+            this.callDuration = this.call.audioDuration || 0;
 
             if (Array.isArray(this.call.frequencies) && this.call.frequencies.length) {
                 const frequency = this.call.frequencies.reduce((p, v) => (v.pos || 0) <= time ? v : p, {});

--- a/client/src/app/components/rdio-scanner/rdio-scanner.ts
+++ b/client/src/app/components/rdio-scanner/rdio-scanner.ts
@@ -45,6 +45,7 @@ export interface RdioScannerCall {
     };
     audioName?: string;
     audioType?: string;
+    audioDuration?: number;
     dateTime: Date;
     frequencies?: RdioScannerCallFrequency[];
     frequency?: number;

--- a/client/src/app/components/rdio-scanner/search/search.component.html
+++ b/client/src/app/components/rdio-scanner/search/search.component.html
@@ -35,6 +35,14 @@
                 <span>{{ row?.dateTime | date:'HH:mm' }}</span>
             </mat-cell>
         </ng-container>
+        <ng-container matColumnDef="duration">
+            <mat-header-cell *matHeaderCellDef>
+                <span>Duration</span>
+            </mat-header-cell>
+            <mat-cell *matCellDef="let row">
+                <span>{{ row?.audioDuration / 1000 | number:'1.0-1' }}s</span>
+            </mat-cell>
+        </ng-container>
         <ng-container matColumnDef="system">
             <mat-header-cell *matHeaderCellDef>
                 <span>System</span>
@@ -59,9 +67,9 @@
                 <span>{{ row?.talkgroupData?.name }}</span>
             </mat-cell>
         </ng-container>
-        <mat-header-row *matHeaderRowDef="['control', 'date', 'time', 'system', 'alpha', 'name']">
+        <mat-header-row *matHeaderRowDef="['control', 'date', 'time', 'duration', 'system', 'alpha', 'name']">
         </mat-header-row>
-        <mat-row *matRowDef="let row; columns: ['control', 'date', 'time', 'system', 'alpha', 'name']">
+        <mat-row *matRowDef="let row; columns: ['control', 'date', 'time', 'duration', 'system', 'alpha', 'name']">
         </mat-row>
     </mat-table>
     <mat-progress-bar color="primary" [mode]="resultsPending ? 'query' : 'determinate'">

--- a/client/src/app/components/rdio-scanner/search/search.component.scss
+++ b/client/src/app/components/rdio-scanner/search/search.component.scss
@@ -48,12 +48,13 @@
     }
 
     &:nth-child(2),
-    &:nth-child(3) {
+    &:nth-child(3),
+    &:nth-child(4) {
       flex: 0 0 50px;
     }
 
-    &:nth-child(4),
-    &:nth-child(5) {
+    &:nth-child(5),
+    &:nth-child(6) {
       flex: 0 0 20%;
     }
 

--- a/server/lib/rdio-scanner/index.js
+++ b/server/lib/rdio-scanner/index.js
@@ -39,6 +39,7 @@ const rs003OptimizeCalls = require('./migrations/20191126135515-optimize-rdio-sc
 const rs004NewV3Tables = require('./migrations/20191220093214-new-v3-tables');
 const rs005OptimizeCalls = require('./migrations/20200123094105-optimize-rdio-scanner-calls');
 const rs006NewV4Tables = require('./migrations/20200428132918-new-v4-tables');
+const rs007AddAudioDurationCol = require('./migrations/20201228032605-add-duration');
 
 const migrations = [
     { name: '20191028144433-create-rdio-scanner-system', up: rs001CreateSystem.up, down: rs001CreateSystem.down },
@@ -47,6 +48,7 @@ const migrations = [
     { name: '20191220093214-new-v3-tables', up: rs004NewV3Tables.up, down: rs004NewV3Tables.down },
     { name: '20200123094105-optimize-rdio-scanner-calls', up: rs005OptimizeCalls.up, down: rs005OptimizeCalls.down },
     { name: '20200428132918-new-v4-tables', up: rs006NewV4Tables.up, down: rs006NewV4Tables.down },
+    { name: '20201228032605-add-duration', up: rs007AddAudioDurationCol.up, down: rs007AddAudioDurationCol.down },
 ];
 
 class RdioScanner extends EventEmitter {

--- a/server/lib/rdio-scanner/migrations/20201228032605-add-duration.js
+++ b/server/lib/rdio-scanner/migrations/20201228032605-add-duration.js
@@ -1,0 +1,59 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2019-2020 Chrystian Huot
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+'use strict';
+
+module.exports = {
+
+    up: async (queryInterface, Sequelize) => {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            // TODO: fill durations of all existing rows
+
+            await queryInterface.addColumn(
+              'rdioScannerCalls', 'audioDuration',
+              { type: Sequelize.INTEGER, allowNull: false, defaultValue: 0 },
+              { transaction },
+              );
+
+            await transaction.commit();
+
+        } catch (err) {
+            await transaction.rollback();
+
+            throw err;
+        }
+    },
+
+    down: async (queryInterface, ) => {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            await queryInterface.removeColumn('rdioScannerCalls', 'audioDuration', { transaction });
+
+            await transaction.commit();
+
+        } catch (err) {
+            await transaction.rollback();
+
+            throw err;
+        }
+    },
+};

--- a/server/lib/rdio-scanner/models/call.js
+++ b/server/lib/rdio-scanner/models/call.js
@@ -51,6 +51,12 @@ rdioScannerCallFactory.schema = {
         type: DataTypes.STRING,
         allowNull: true,
     },
+    // Duration of clip, in milliseconds
+    audioDuration: {
+        type: DataTypes.INTEGER,
+        defaultValue: 0,
+        allowNull: false,
+    },
     dateTime: {
         type: DataTypes.DATE,
         allowNull: false,


### PR DESCRIPTION
This PR adds a new DB column, `audioDuration`, to record the duration of each call (as milliseconds in an integer). On call import, [`ffprobe`](https://ffmpeg.org/ffprobe.html) (packaged with ffmpeg) is used to get the audio clip's duration and record it in the DB. This duration is then displayed for the currently-active call, the previous call history table, and the search call page.

Other changes of note:

 - The new migration does _not_ fill duration values for existing audio clips. This can be added, if desired, but I figured it may be prohibitively slow, depending on DB size. Perhaps it may be more appropriate to add a standalone CLI command to backfill. 

 - Class names were added to the main panel history table columns to allow the SCSS to address them by name, rather than index.


## Screenshots
### Main
![image](https://user-images.githubusercontent.com/33840/103202649-fbc75f00-48c0-11eb-8bca-667fd375680f.png)

NOTE: "Length" is used instead of "Duration" when displaying on the main panel due to size constraints.

### Search
![image](https://user-images.githubusercontent.com/33840/103202730-35986580-48c1-11eb-875a-90f681ea828d.png)
