### PR TITLE
TypeError

### DIFF
--- a/server/lib/rdio-scanner/controller.js
+++ b/server/lib/rdio-scanner/controller.js
@@ -985,7 +985,8 @@ export class Controller extends EventEmitter {
             }, 15 * 60 * 1000);
 
         } else {
-            this.pruneScheduler = null;
+            // this causes TypeError because this.pruneScheduer() is no longer a function
+            // this.pruneScheduler = null;
         }
     }
 


### PR DESCRIPTION
setting this.pruneScheduler to null causes this.pruneScheduler() to fail because it is null instead of being a function