### PR TITLE
Add high efficiency aac support 

### DIFF
--- a/client/src/app/components/rdio-scanner/admin/admin.service.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.service.ts
@@ -131,6 +131,7 @@ export interface LogsQueryOptions {
 export interface Options {
     afsSystems?: string;
     audioConversion?: 0 | 1 | 2 | 3;
+    audioCompression?: 0 | 1 | 2 | 3 | 4 | 5;
     autoPopulate?: boolean;
     branding?: string;
     dimmerDelay?: number;
@@ -498,6 +499,7 @@ export class RdioScannerAdminService implements OnDestroy {
         return this.ngFormBuilder.group({
             afsSystems: [options?.afsSystems, this.validateAfsSystems()],
             audioConversion: [options?.audioConversion],
+            audioCompression: [options?.audioCompression],
             autoPopulate: [options?.autoPopulate],
             branding: [options?.branding],
             dimmerDelay: [options?.dimmerDelay, [Validators.required, Validators.min(0)]],

--- a/client/src/app/components/rdio-scanner/admin/admin.service.ts
+++ b/client/src/app/components/rdio-scanner/admin/admin.service.ts
@@ -131,7 +131,7 @@ export interface LogsQueryOptions {
 export interface Options {
     afsSystems?: string;
     audioConversion?: 0 | 1 | 2 | 3;
-    audioCompression?: 0 | 1 | 2 | 3 | 4 | 5;
+    audioCompression?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
     autoPopulate?: boolean;
     branding?: string;
     dimmerDelay?: number;

--- a/client/src/app/components/rdio-scanner/admin/config/options/options.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/options/options.component.html
@@ -37,6 +37,22 @@
     </div>
     <div class="row">
         <p>
+            <span class="mat-body">Audio Compression</span><br>
+            <span class="mat-caption">Controls the amount of audio compression</span>
+        </p>
+        <mat-form-field floatLabel="never">
+            <mat-select formControlName="audioCompression" placeholder="Audio Compression">
+                <mat-option [value]="0">Default compression</mat-option>
+                <mat-option [value]="1">Low compression</mat-option>
+                <mat-option [value]="2">Medium compression</mat-option>
+                <mat-option [value]="3">High compression</mat-option>
+                <mat-option [value]="4">Ultra compression</mat-option>
+                <mat-option [value]="5">Extreme compression</mat-option>
+            </mat-select>
+        </mat-form-field>
+    </div>
+    <div class="row">
+        <p>
             <span class="mat-body">Auto Populate</span><br>
             <span class="mat-caption">Globaly allows the automatic creation of unconfigured systems and
                 talkgroups.</span>

--- a/client/src/app/components/rdio-scanner/admin/config/options/options.component.html
+++ b/client/src/app/components/rdio-scanner/admin/config/options/options.component.html
@@ -38,16 +38,18 @@
     <div class="row">
         <p>
             <span class="mat-body">Audio Compression</span><br>
-            <span class="mat-caption">Controls the amount of audio compression</span>
+            <span class="mat-caption">Controls the amount of audio compression for audio files.</span>
         </p>
         <mat-form-field floatLabel="never">
             <mat-select formControlName="audioCompression" placeholder="Audio Compression">
-                <mat-option [value]="0">Default compression</mat-option>
-                <mat-option [value]="1">Low compression</mat-option>
-                <mat-option [value]="2">Medium compression</mat-option>
-                <mat-option [value]="3">High compression</mat-option>
-                <mat-option [value]="4">Ultra compression</mat-option>
-                <mat-option [value]="5">Extreme compression</mat-option>
+                <mat-option [value]="0">Automatic compression (Default)</mat-option>
+                <mat-option [value]="1">Low compression, stable, 32 KB/s (AAC-LC)</mat-option>
+                <mat-option [value]="2">Medium compression, stable, 24 KB/s (AAC-LC)</mat-option>
+                <mat-option [value]="3">High compression, stable, 16 KB/s (AAC-LC)</mat-option>
+                <mat-option [value]="4">Ultra compression, unstable, 12 KB/s (AAC-HE)</mat-option>
+                <mat-option [value]="5">Extreme compression, unstable, 8 KB/s (AAC-HE)</mat-option>
+                <mat-option [value]="6">Experimental compression, HAZARDOUS, 12 KB/s (AAC-HE-v2)</mat-option>
+                <mat-option [value]="7">Experimental compression, HAZARDOUS, 8 KB/s (AAC-HE-v2)</mat-option>
             </mat-select>
         </mat-form-field>
     </div>

--- a/server/controller.go
+++ b/server/controller.go
@@ -280,7 +280,7 @@ func (controller *Controller) IngestCall(call *Call) {
 		}
 	}
 
-	if err := controller.FFMpeg.Convert(call, controller.Systems, controller.Tags, controller.Options.AudioConversion); err != nil {
+	if err := controller.FFMpeg.Convert(call, controller.Systems, controller.Tags, controller.Options.AudioConversion, controller.Options.AudioCompression); err != nil {
 		controller.Logs.LogEvent(LogLevelWarn, err.Error())
 	}
 

--- a/server/defaults.go
+++ b/server/defaults.go
@@ -97,7 +97,7 @@ var defaults Defaults = Defaults{
 	keypadBeeps: "uniden",
 	options: DefaultOptions{
 		audioConversion:             AUDIO_CONVERSION_ENABLED,
-		audioCompression:            AUDIO_COMPRESSION_DEFAULT,
+		audioCompression:            AUDIO_COMPRESSION_MEDIUM,
 		autoPopulate:                true,
 		dimmerDelay:                 5000,
 		disableDuplicateDetection:   false,

--- a/server/defaults.go
+++ b/server/defaults.go
@@ -52,6 +52,7 @@ type DefaultDownstream struct {
 type DefaultOptions struct {
 	autoPopulate                bool
 	audioConversion             uint
+	audioCompression            uint
 	dimmerDelay                 uint
 	disableDuplicateDetection   bool
 	duplicateDetectionTimeFrame uint
@@ -96,6 +97,7 @@ var defaults Defaults = Defaults{
 	keypadBeeps: "uniden",
 	options: DefaultOptions{
 		audioConversion:             AUDIO_CONVERSION_ENABLED,
+		audioCompression:            AUDIO_COMPRESSION_DEFAULT,
 		autoPopulate:                true,
 		dimmerDelay:                 5000,
 		disableDuplicateDetection:   false,

--- a/server/ffmpeg.go
+++ b/server/ffmpeg.go
@@ -61,7 +61,7 @@ func NewFFMpeg() *FFMpeg {
 	return ffmpeg
 }
 
-func (ffmpeg *FFMpeg) Convert(call *Call, systems *Systems, tags *Tags, mode uint) error {
+func (ffmpeg *FFMpeg) Convert(call *Call, systems *Systems, tags *Tags, mode uint, compression uint) error {
 	var (
 		args = []string{"-i", "-"}
 		err  error
@@ -102,7 +102,21 @@ func (ffmpeg *FFMpeg) Convert(call *Call, systems *Systems, tags *Tags, mode uin
 		}
 	}
 
-	args = append(args, "-ar", "16000", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "8k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")
+	if compression == AUDIO_COMPRESSION_LOW {
+		args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-b:a", "32k")
+	} else if compression == AUDIO_COMPRESSION_MEDIUM {
+		args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-b:a", "24k")
+	} else if compression == AUDIO_COMPRESSION_HIGH {
+		args = append(args, "-ar", "16k", "-c:a", "libfdk_aac", "-b:a", "16k")
+	} else if compression == AUDIO_COMPRESSION_ULTRA {
+		args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "12k")
+	} else if compression == AUDIO_COMPRESSION_EXTREME {
+		args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "8k")
+	} else {
+		args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-b:a", "24k")
+	}
+
+	args = append(args, "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")
 
 	cmd := exec.Command("ffmpeg", args...)
 	cmd.Stdin = bytes.NewReader(call.Audio)

--- a/server/ffmpeg.go
+++ b/server/ffmpeg.go
@@ -102,7 +102,7 @@ func (ffmpeg *FFMpeg) Convert(call *Call, systems *Systems, tags *Tags, mode uin
 		}
 	}
 
-	args = append(args, "-c:a", "aac", "-b:a", "32k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")
+	args = append(args, "-ar", "16000", "-ac", "2", "-c:a", "libfdk_aac", "-profile:a", "aac_he_v2", "-b:a", "8k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")
 
 	cmd := exec.Command("ffmpeg", args...)
 	cmd.Stdin = bytes.NewReader(call.Audio)

--- a/server/ffmpeg.go
+++ b/server/ffmpeg.go
@@ -102,18 +102,23 @@ func (ffmpeg *FFMpeg) Convert(call *Call, systems *Systems, tags *Tags, mode uin
 		}
 	}
 
-	if compression == AUDIO_COMPRESSION_LOW {
-		args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-b:a", "32k")
-	} else if compression == AUDIO_COMPRESSION_MEDIUM {
-		args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-b:a", "24k")
-	} else if compression == AUDIO_COMPRESSION_HIGH {
-		args = append(args, "-ar", "16k", "-c:a", "libfdk_aac", "-b:a", "16k")
-	} else if compression == AUDIO_COMPRESSION_ULTRA {
-		args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "12k")
-	} else if compression == AUDIO_COMPRESSION_EXTREME {
-		args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "8k")
-	} else {
-		args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-b:a", "24k")
+	switch compression {
+		case AUDIO_COMPRESSION_LOW:
+			args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-b:a", "32k")
+		case AUDIO_COMPRESSION_MEDIUM:
+			args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-b:a", "24k")
+		case AUDIO_COMPRESSION_HIGH:
+			args = append(args, "-ar", "16k", "-c:a", "libfdk_aac", "-b:a", "16k")
+		case AUDIO_COMPRESSION_ULTRA:
+			args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "12k")
+		case AUDIO_COMPRESSION_EXTREME:
+			args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "8k")
+		case AUDIO_COMPRESSION_BETA_1:
+			args = append(args, "-ar", "32k", "-ac", "2", "-c:a", "libfdk_aac", "-profile:a", "aac_he_v2", "-b:a", "12k")
+		case AUDIO_COMPRESSION_BETA_2:
+			args = append(args, "-ar", "24k", "-ac", "2", "-c:a", "libfdk_aac", "-profile:a", "aac_he_v2", "-b:a", "8k")
+		default:
+			args = append(args, "-c:a", "24k", "-c:a", "libfdk_aac", "-b:a", "24k")
 	}
 
 	args = append(args, "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

--- a/server/ffmpeg.go
+++ b/server/ffmpeg.go
@@ -102,7 +102,7 @@ func (ffmpeg *FFMpeg) Convert(call *Call, systems *Systems, tags *Tags, mode uin
 		}
 	}
 
-	args = append(args, "-ar", "16000", "-ac", "2", "-c:a", "libfdk_aac", "-profile:a", "aac_he_v2", "-b:a", "8k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")
+	args = append(args, "-ar", "16000", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "8k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")
 
 	cmd := exec.Command("ffmpeg", args...)
 	cmd.Stdin = bytes.NewReader(call.Audio)

--- a/server/options.go
+++ b/server/options.go
@@ -63,6 +63,8 @@ const (
 	AUDIO_COMPRESSION_HIGH             = 3
 	AUDIO_COMPRESSION_ULTRA            = 4
 	AUDIO_COMPRESSION_EXTREME          = 5
+	AUDIO_COMPRESSION_BETA_1           = 6
+	AUDIO_COMPRESSION_BETA_2           = 7
 )
 
 func NewOptions() *Options {

--- a/server/options.go
+++ b/server/options.go
@@ -211,6 +211,7 @@ func (options *Options) Read(db *Database) error {
 	options.adminPassword = string(defaultPassword)
 	options.adminPasswordNeedChange = defaults.adminPasswordNeedChange
 	options.AudioConversion = defaults.options.audioConversion
+	options.AudioCompression = defaults.options.audioCompression
 	options.AutoPopulate = defaults.options.autoPopulate
 	options.DimmerDelay = defaults.options.dimmerDelay
 	options.DisableDuplicateDetection = defaults.options.disableDuplicateDetection
@@ -383,6 +384,7 @@ func (options *Options) Write(db *Database) error {
 	if b, err = json.Marshal(map[string]any{
 		"afsSystems":                  options.AfsSystems,
 		"audioConversion":             options.AudioConversion,
+		"audioCompression":            options.AudioCompression,
 		"autoPopulate":                options.AutoPopulate,
 		"branding":                    options.Branding,
 		"dimmerDelay":                 options.DimmerDelay,

--- a/server/options.go
+++ b/server/options.go
@@ -78,6 +78,13 @@ func (options *Options) FromMap(m map[string]any) *Options {
 		options.MaxClients = defaults.options.audioConversion
 	}
 
+	switch v := m["audioCompression"].(type) {
+	case float64:
+		options.AudioCompression = uint(v)
+	default:
+		options.AudioCompression = defaults.options.audioCompression
+	}
+
 	switch v := m["autoPopulate"].(type) {
 	case bool:
 		options.AutoPopulate = v

--- a/server/options.go
+++ b/server/options.go
@@ -56,6 +56,15 @@ const (
 	AUDIO_CONVERSION_ENABLED_LOUD_NORM = 3
 )
 
+const (
+	AUDIO_COMPRESSION_DEFAULT          = 0
+	AUDIO_COMPRESSION_LOW              = 1
+	AUDIO_COMPRESSION_MEDIUM           = 2
+	AUDIO_COMPRESSION_HIGH             = 3
+	AUDIO_COMPRESSION_ULTRA            = 4
+	AUDIO_COMPRESSION_EXTREME          = 5
+)
+
 func NewOptions() *Options {
 	return &Options{
 		mutex: sync.Mutex{},

--- a/server/options.go
+++ b/server/options.go
@@ -27,6 +27,7 @@ import (
 type Options struct {
 	AfsSystems                  string `json:"afsSystems"`
 	AudioConversion             uint   `json:"audioConversion"`
+	AudioCompression            uint   `json:"audioCompression"`
 	AutoPopulate                bool   `json:"autoPopulate"`
 	Branding                    string `json:"branding"`
 	DimmerDelay                 uint   `json:"dimmerDelay"`


### PR DESCRIPTION
Changed the FFmpeg arguments to enable High Efficiency AAC (HE-AAC) encoding for recorded calls to reduce storage usage while archiving calls in `rdio-scanner.db`.

Go to #479 for feature request

Added a configuration option to enable or disable this feature for backwards-compatibility with older versions of rdio-scanner or FFmpeg. I was able to shrink a 22,262 kb recording into a 6,554 kb recording using HE-AAC. 

High Efficiency AAC v2 (HE-AAC-v2) is experimental because it requires stereo audio for the parametric encoder which could cause problems. 

Below is the possible presets for audio compression including experimental HE-AAC-v2 presets. These presents are included to create a config option for controlling the amount of compression depending on your needs. Currently only the standard presets are supported.

```go
// server/ffmpeg.go

// --- standard ---

// AAC-LC arguments (low compression) 21,651 kb
args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-b:a", "32k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

// AAC-LC arguments (medium compression) 16,609 kb
args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-b:a", "24k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

// AAC-LC arguments (high compression) 11,603 kb
args = append(args, "-ar", "16k", "-c:a", "libfdk_aac", "-b:a", "16k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

// HE-AAC arguments (ultra compression) 9,124 kb
args = append(args, "-ar", "32k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "12k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

// HE-AAC arguments (extreme compression) 6,582 kb
args = append(args, "-ar", "24k", "-c:a", "libfdk_aac", "-profile:a", "aac_he", "-b:a", "8k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

// --- Experimental ---

// HE-AAC v2 arguments (experimental compression a) 9,193 kb
args = append(args, "-ar", "32k", "-ac", "2", "-c:a", "libfdk_aac", "-profile:a", "aac_he_v2", "-b:a", "12k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

// HE-AAC v2 arguments (experimental compression b) 6,651 kb
args = append(args, "-ar", "24k", "-ac", "2", "-c:a", "libfdk_aac", "-profile:a", "aac_he_v2", "-b:a", "8k", "-movflags", "frag_keyframe+empty_moov", "-f", "ipod", "-")

```